### PR TITLE
Make checkstyle's NewlineAtEndOfFile OS independent

### DIFF
--- a/config/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/config/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -317,6 +317,7 @@
   </module>
   <module name="NewlineAtEndOfFile">
     <property name="severity" value="error"/>
+    <property name="lineSeparator" value="lf_cr_crlf"/>
   </module>
   <module name="SuppressWithNearbyCommentFilter"/>
 </module>


### PR DESCRIPTION
Make checkstyle's NewlineAtEndOfFile OS independent