### PR TITLE
Allow checkstyle for PMD to run on Windows

### DIFF
--- a/config/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/config/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -322,6 +322,7 @@
   </module>
   <module name="NewlineAtEndOfFile">
     <property name="severity" value="error"/>
+    <property name="lineSeparator" value="lf"/>
   </module>
   <module name="SuppressWithNearbyCommentFilter"/>
 </module>


### PR DESCRIPTION
```
P:\projects\contrib\github-pmd>mvnw -pl pmd-core checkstyle:checkstyle
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building PMD Core 6.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-checkstyle-plugin:2.17:checkstyle (default-cli) @ pmd-core ---
[INFO] There are 457 errors reported by Checkstyle 7.2 with /net/sourceforge/pmd/pmd-checkstyle-config.xml ruleset.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21.112 s
[INFO] Finished at: 2018-01-01T13:59:19Z
[INFO] Final Memory: 42M/815M
[INFO] ------------------------------------------------------------------------
```
From `p:\projects\contrib\github-pmd\pmd-core\target\checkstyle-result.xml` all those errors are:
```
<file name="P:\projects\contrib\github-pmd\pmd-core\src\main\java\....java">
<error line="0" severity="error" message="File does not end with a newline." source="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck"/>
```

Checkstyle by default uses platform-dependent line endings, so on Windows machines it is looking for `0D, 0A` (cr, lf) at the end of file, but your codebase being unix based it finds all `0A`s (lf) only.