### PR TITLE
Add exception to FxIdNamingConvention

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-ui-dogfood-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-ui-dogfood-config.xml
@@ -30,6 +30,7 @@
                   [not(Type/@TypeImage = 'ToggleButton' and ends-with(@VariableName, 'Toggle'))]
                   [not(Type/@TypeImage = 'TextArea' or ends-with(Type/@TypeImage, 'CodeArea') and ends-with(@VariableName, 'Area'))]
                   [not(Type/@TypeImage = 'TableColumn' and ends-with(@VariableName, 'Column'))]
+                  [not(ends-with(Type/@TypeImage, 'TitledPane') and ends-with(@VariableName, 'Pane'))]
                   (: This last clause allows variables to be named the same as their type, modulo Camel case :)
                   (: Ideally we would only allow this for our custom types, but there's currently no easy :)
                   (: way to get the type name of a node to check the package. :)


### PR DESCRIPTION
Adds an exception to the rule to handle the new control (ToolbarTitledPane) introduced in pmd/pmd#1576