### PR TITLE
New rule AlwaysCallSuperWhenNotUsingRuleChain

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-dogfood-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-dogfood-config.xml
@@ -603,4 +603,27 @@ PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression[
         </properties>
     </rule>
 
+    <rule name="AlwaysCallSuperWhenNotUsingRuleChain"
+          language="java"
+          message="Always call super.visit() when not using rulechain"
+          typeResolution="true"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>Just returning without calling super stops visiting of nested nodes like inner classes.</description>
+        <priority>1</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//ClassOrInterfaceDeclaration[pmd-java:typeIs('net.sourceforge.pmd.Rule')][@Abstract = false()][@Interface = false()]
+  (: Not using the rulechain :)
+  [not(./*/*/ConstructorDeclaration//PrimaryExpression/PrimaryPrefix/Name[@Image = 'addRuleChainVisit'])]
+  (: and not calling super.visit! :)
+  [./*/*/MethodDeclaration[@Name = 'visit'][not(.//PrimaryExpression[./PrimaryPrefix[@SuperModifier = true()]][./PrimarySuffix[@Image = 'visit']])]]
+]]>
+                </value>
+            </property>
+        </properties>
+    </rule>
+
 </ruleset>

--- a/src/test/java/net/sourceforge/pmd/buildtools/AlwaysCallSuperWhenNotUsingRuleChainTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/AlwaysCallSuperWhenNotUsingRuleChainTest.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.buildtools;
+
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+
+public class AlwaysCallSuperWhenNotUsingRuleChainTest extends SimpleAggregatorTst {
+    @Override
+    public void setUp() {
+        addRule("net/sourceforge/pmd/pmd-dogfood-config.xml", "AlwaysCallSuperWhenNotUsingRuleChain");
+    }
+}

--- a/src/test/resources/net/sourceforge/pmd/buildtools/xml/AlwaysCallSuperWhenNotUsingRuleChain.xml
+++ b/src/test/resources/net/sourceforge/pmd/buildtools/xml/AlwaysCallSuperWhenNotUsingRuleChain.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Rule without RuleChain and without super</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.buildtools.testsupport;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+
+public class MyRule extends AbstractJavaRule {
+    @Override
+    public Object visit(ASTCompilationUnit node, Object data) {
+        return data;
+    }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>Rule without RuleChain and with super</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.buildtools.testsupport;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+
+public class MyRule extends AbstractJavaRule {
+    @Override
+    public Object visit(ASTCompilationUnit node, Object data) {
+        return super.visit(node, data);
+    }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore abstract rules</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.buildtools.testsupport;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+
+public abstract class AbstractJavaRule extends AbstractRule {
+    @Override
+    public Object visit(ASTCompilationUnit node, Object data) {
+        return visit((JavaNode) node, data);
+    }
+
+    @Override
+    public Object visit(JavaNode node, Object data) {
+        for (JavaNode child : node.children()) {
+            child.jjtAccept(this, data);
+        }
+        return data;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore interfaces</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.buildtools.testsupport;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+
+public interface AbstractJavaRule extends Rule {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Only consider visit methods</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.buildtools.testsupport;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+
+public class MyRule extends AbstractJavaRule {
+    public void unrelatedMethod() { }
+}
+     ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
This adds a new custom rule that finds rule implementation, that don't use rule chain, but forget to call "super.visit" in one of the visit methods. This means, these rules probably skip some AST traversal and are most likely wrong.