### PR TITLE
Update Checkstyle JavadocMethodCheck config to change 'scope' to 'accessModifiers'

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -25,7 +25,7 @@
     </module>
     <module name="JavadocMethod">
       <property name="severity" value="warning"/>
-      <property name="scope" value="protected"/>
+      <property name="accessModifiers" value="public,protected"/>
     </module>
     <module name="JavadocStyle">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
From failure at https://checkstyle.semaphoreci.com/jobs/d8ae46ab-f367-4a12-b17c-a7991ec296d7 in reference to https://github.com/checkstyle/checkstyle/issues/7417

Checkstyle has changed the `scope` property to `accessModifiers` in `JavadocMethodCheck`. This PR will update pmd build-tools Checkstyle config to accommodate this (breaking) change, which will be included in the next Checkstyle release. When the next Checkstyle version is released, I will rebase this PR and update the Checkstyle version number.

Successful Checkstyle execution with new property on this project: https://checkstyle.semaphoreci.com/jobs/4a61d33f-a60d-4812-8269-57be608f2de9