### PR TITLE
Implement new PMD Console Reporter for surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
         <pmd.version>6.53.0</pmd.version> <!-- pmd version used for tests -->
+        <surefire.version>3.0.0-M8</surefire.version>
     </properties>
 
     <dependencyManagement>
@@ -88,6 +89,18 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>maven-surefire-common</artifactId>
+            <version>${surefire.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-java</artifactId>
@@ -147,7 +160,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>${surefire.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporter.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporter.java
@@ -1,0 +1,183 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.buildtools.surefire;
+
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.plugin.surefire.report.TestSetStats;
+import org.apache.maven.plugin.surefire.report.WrappedReportEntry;
+import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.apache.maven.surefire.extensions.StatelessTestsetInfoConsoleReportEventListener;
+import org.apache.maven.surefire.shared.utils.logging.MessageBuilder;
+import org.apache.maven.surefire.shared.utils.logging.MessageUtils;
+
+class AccumulatingConsoleReporter extends StatelessTestsetInfoConsoleReportEventListener<WrappedReportEntry, TestSetStats> {
+    private final boolean showSuccessfulTests;
+
+    private final boolean showFailedTests;
+
+    private final boolean showSkippedTests;
+
+    public AccumulatingConsoleReporter(ConsoleLogger logger, boolean showSuccessfulTests, boolean showFailedTests, boolean showSkippedTests) {
+        super(logger);
+        this.showSuccessfulTests = showSuccessfulTests;
+        this.showFailedTests = showFailedTests;
+        this.showSkippedTests = showSkippedTests;
+    }
+
+    private final Map<String, Deque<String>> nestedTestSetNames = new HashMap<>();
+    private final Map<String, TestSetStats> accumulatedTestSetStats = new HashMap<>();
+    private final Map<String, Integer> totalElapsedTimeMillis = new HashMap<>();
+
+    @Override
+    public void testSetStarting(TestSetReportEntry report) {
+        String source = getOuterTestClass(report);
+        if (!nestedTestSetNames.containsKey(source)) {
+            nestedTestSetNames.put(source, new LinkedList<String>());
+        }
+        Deque<String> nesting = nestedTestSetNames.get(source);
+        if (nesting.isEmpty()) {
+            nesting.addLast(source);
+            accumulatedTestSetStats.put(source, new TestSetStats(true, true));
+            totalElapsedTimeMillis.put(source, 0);
+            MessageBuilder buffer = MessageUtils.buffer();
+            getConsoleLogger().info("Running " + buffer.strong(source));
+        } else {
+            String fullName = report.getSourceText();
+            if (fullName == null) {
+                fullName = report.getSourceName();
+            }
+            fullName = fullName.replaceAll("\\$", " ");
+            nesting.addLast(fullName);
+        }
+    }
+
+    @Override
+    public void testSetCompleted(WrappedReportEntry report, TestSetStats testSetStats, List<String> testResults) {
+        String outerTestClass = getOuterTestClass(report);
+        Deque<String> nesting = nestedTestSetNames.get(outerTestClass);
+
+        int elapsedMillis = totalElapsedTimeMillis.get(outerTestClass) + report.getElapsed();
+        totalElapsedTimeMillis.put(outerTestClass, elapsedMillis);
+
+        TestSetStats accumulated = accumulatedTestSetStats.get(outerTestClass);
+        accumulateTestSetStats(accumulated, testSetStats.getReportEntries());
+
+        String prefix = "└─ ";
+        if ((testSetStats.getErrors() > 0 || testSetStats.getFailures() > 0) && showFailedTests
+            || testSetStats.getSkipped() > 0 && showSkippedTests
+            || testSetStats.getCompletedCount() > 0 && showSuccessfulTests) {
+            if (!testSetStats.getReportEntries().isEmpty() && nesting.size() > 1) {
+                String previousTestSetName = null;
+                for (String fullTestSetName : nesting) {
+                    if (previousTestSetName != null) {
+                        prefix = "    " + prefix;
+                        String shortenedTestSetName = fullTestSetName;
+                        if (fullTestSetName.startsWith(previousTestSetName)) {
+                            shortenedTestSetName = fullTestSetName.substring(previousTestSetName.length());
+                        }
+                        getConsoleLogger().info(prefix + shortenedTestSetName);
+                    }
+                    previousTestSetName = fullTestSetName + " ";
+                }
+            }
+        }
+
+        String testSetName = getTestSetName(report);
+        // individual tests
+        for (WrappedReportEntry entry : testSetStats.getReportEntries()) {
+            String shortTestCaseName = getTestCaseName(entry, testSetName);
+            MessageBuilder buffer = MessageUtils.buffer();
+            if (entry.isErrorOrFailure() && showFailedTests) {
+                buffer.failure("✘ ").failure(shortTestCaseName);
+                getConsoleLogger().info("    " + prefix + buffer);
+            } else if (entry.isSkipped() && showSkippedTests) {
+                buffer.warning("↷ ").warning(shortTestCaseName);
+                getConsoleLogger().info("    " + prefix + buffer);
+            } else if (showSuccessfulTests) {
+                buffer.success("✔ ").a(shortTestCaseName);
+                getConsoleLogger().info("    " + prefix + buffer);
+            }
+        }
+
+        if (nesting.size() == 1) {
+            WrappedReportEntry reportWithTotalElapsedMillis = new WrappedReportEntry(report,
+                    report.getReportEntryType(), elapsedMillis, null, null);
+            getConsoleLogger().info(accumulated.getColoredTestSetSummary(reportWithTotalElapsedMillis, false));
+
+            accumulatedTestSetStats.remove(outerTestClass);
+            nestedTestSetNames.remove(outerTestClass);
+            totalElapsedTimeMillis.remove(outerTestClass);
+        } else {
+            nesting.pollLast();
+        }
+    }
+
+    private static String getTestSetName(WrappedReportEntry report) {
+        String testSetName = report.getSourceText();
+        if (testSetName == null) {
+            testSetName = report.getSourceName();
+        }
+        return testSetName;
+    }
+
+    private static String getTestCaseName(WrappedReportEntry entry, String testSetName) {
+        String testCaseName = entry.getNameText();
+        if (testCaseName == null) {
+            testCaseName = entry.getName();
+        }
+        if (testCaseName == null) {
+            testCaseName = getTestSetName(entry);
+        }
+
+        String shortenedTestCaseName = testCaseName;
+        if (testCaseName.startsWith(testSetName)) {
+            shortenedTestCaseName = testCaseName.substring(testSetName.length());
+        }
+        if (shortenedTestCaseName.isEmpty()) {
+            shortenedTestCaseName = "[unnamed test case]";
+        }
+
+        return shortenedTestCaseName;
+    }
+
+    private static void accumulateTestSetStats(TestSetStats accumulated, Collection<WrappedReportEntry> reportEntries) {
+        for (WrappedReportEntry entry : reportEntries) {
+            switch (entry.getReportEntryType()) {
+                case SUCCESS:
+                    accumulated.testSucceeded(entry);
+                    break;
+                case SKIPPED:
+                    accumulated.testSkipped(entry);
+                    break;
+                case FAILURE:
+                    accumulated.testFailure(entry);
+                    break;
+                case ERROR:
+                    accumulated.testError(entry);
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    private static String getOuterTestClass(TestSetReportEntry report) {
+        String source = report.getSourceName();
+        int dollar = source.indexOf('$');
+        if (dollar != -1) {
+            source = source.substring(0, dollar);
+        }
+        return source;
+    }
+}

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/PMDStatelessTestSetInfoConsoleReporter.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/PMDStatelessTestSetInfoConsoleReporter.java
@@ -1,0 +1,156 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.buildtools.surefire;
+
+import org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter;
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.plugin.surefire.report.TestSetStats;
+import org.apache.maven.plugin.surefire.report.WrappedReportEntry;
+import org.apache.maven.surefire.extensions.StatelessTestsetInfoConsoleReportEventListener;
+
+/**
+ * <p>This is a test set info reporter extension for maven surefire. Unlike the default reporter, all test sets
+ * that belong to the same test class (that includes nested test sets) are accumulated and the summary
+ * is reported only once for the test class. This avoids seeing summaries with 0 tests executed,
+ * which are test sets that only act as container nodes without tests.</p>
+ *
+ * <p>It outputs to the console. It uses the default implementations for writing the text report files
+ * in target/surefire-reports.</p>
+ *
+ * <p>It can be configured to list individual test cases as well. This is useful for failed test cases.
+ * This is inspired by maven-surefire-junit5-tree-reporter.</p>
+ *
+ * <p>The names of the individual test cases are defined in a way, that it works also with kotest. Tests
+ * from kotest only provide the class as the source but no methods. This reporter will fall back to the
+ * alternative user-defined naming (which can be achieved in JUnit5 via @DisplayName). Kotest uses the
+ * same, but it contains the full path of the nested test sets as well. This reporter extracts the
+ * names accordingly.</p>
+ *
+ * <p>Configuration in pom.xml:
+ * <pre>{@code
+ * <plugin>
+ *     <groupId>org.apache.maven.plugins</groupId>
+ *     <artifactId>maven-surefire-plugin</artifactId>
+ *     <version>${surefire.version}</version>
+ *     <configuration>
+ *         <statelessTestsetInfoReporter implementation="net.sourceforge.pmd.buildtools.surefire.PMDStatelessTestsetInfoConsoleReporter">
+ *             <showFailedTests>true</showFailedTests>
+ *             <showSuccessfulTests>false</showSuccessfulTests>
+ *             <showSkippedTests>true</showSkippedTests>
+ *             <usePhrasedFileName>true</usePhrasedFileName>
+ *             <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+ *             <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+ *         </statelessTestsetInfoReporter>
+ *
+ *         <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+ *             <usePhrasedFileName>true</usePhrasedFileName>
+ *             <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+ *             <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+ *             <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+ *         </statelessTestsetReporter>
+ *     </configuration>
+ * </plugin>
+ * }</pre>
+ *
+ * <p>Example output:
+ * <pre>{@code
+ * [INFO] --- maven-surefire-plugin:3.0.0-M8:test (default-cli) @ pmd-java ---
+ * [INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
+ * [INFO]
+ * [INFO] -------------------------------------------------------
+ * [INFO]  T E S T S
+ * [INFO] -------------------------------------------------------
+ * [INFO] Running net.sourceforge.pmd.lang.java.ast.ASTPatternTest
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 1.3
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 1.4
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 1.5
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 1.6
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 1.7
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 1.8
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 9
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 10
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 11
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 12
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 13
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 14
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO]     └─ Test patterns only available on JDK16 or higher (including preview)
+ * [INFO]         └─ Java 15
+ * [INFO]             └─ ✘ [unnamed test case]
+ * [INFO] Tests run: 31, Failures: 13, Errors: 0, Skipped: 0, Time elapsed: 2.198 s <<< FAILURE! - in net.sourceforge.pmd.lang.java.ast.ASTPatternTest
+ * [INFO] Running net.sourceforge.pmd.lang.java.ast.Java15KotlinTest
+ * [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.167 s - in net.sourceforge.pmd.lang.java.ast.Java15KotlinTest
+ * [INFO] Running net.sourceforge.pmd.lang.java.ast.JUnit5Test
+ * [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.154 s - in net.sourceforge.pmd.lang.java.ast.JUnit5Test
+ * [INFO] Running net.sourceforge.pmd.lang.java.symboltable.MethodNameDeclarationTest
+ * [INFO]     └─ ✘ testEquality
+ * [INFO] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.042 s <<< FAILURE! - in net.sourceforge.pmd.lang.java.symboltable.MethodNameDeclarationTest
+ * [INFO]
+ * }</pre>
+ *
+ * @see <a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html#surefire-extensions-and-reports-configuration-for-displayname">Surefire Extensions and Reports Configuration for @DisplayName</a>
+ * @see <a href="https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter">Maven Surefire JUnit5 TreeView Extension</a>
+ */
+public class PMDStatelessTestSetInfoConsoleReporter extends JUnit5StatelessTestsetInfoReporter {
+
+    private boolean showSuccessfulTests;
+
+    private boolean showFailedTests;
+
+    private boolean showSkippedTests;
+
+    public boolean isShowSuccessfulTests() {
+        return showSuccessfulTests;
+    }
+
+    public void setShowSuccessfulTests(boolean showSuccessfulTests) {
+        this.showSuccessfulTests = showSuccessfulTests;
+    }
+
+    public boolean isShowFailedTests() {
+        return showFailedTests;
+    }
+
+    public void setShowFailedTests(boolean showFailedTests) {
+        this.showFailedTests = showFailedTests;
+    }
+
+    public boolean isShowSkippedTests() {
+        return showSkippedTests;
+    }
+
+    public void setShowSkippedTests(boolean showSkippedTests) {
+        this.showSkippedTests = showSkippedTests;
+    }
+
+    @Override
+    public StatelessTestsetInfoConsoleReportEventListener<WrappedReportEntry, TestSetStats> createListener(
+            ConsoleLogger logger) {
+        return new AccumulatingConsoleReporter(logger, showSuccessfulTests, showFailedTests, showSkippedTests);
+    }
+}

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
@@ -1,0 +1,138 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.buildtools.surefire;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.plugin.surefire.report.ReportEntryType;
+import org.apache.maven.plugin.surefire.report.TestSetStats;
+import org.apache.maven.plugin.surefire.report.WrappedReportEntry;
+import org.apache.maven.surefire.api.report.RunMode;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AccumulatingConsoleReporterTest {
+    private static long testRunId = 1L;
+
+    private static final List<String> EMPTY = new ArrayList<>();
+    private static final TestSetStats EMPTY_STATS = new TestSetStats(true, true);
+    private static final String NL = System.lineSeparator();
+
+    private MockedConsoleLogger logger;
+    private AccumulatingConsoleReporter reporter;
+    @Before
+    public void setup() {
+        logger = new MockedConsoleLogger();
+        reporter = new AccumulatingConsoleReporter(logger, false, true, true);
+    }
+
+
+    @Test
+    public void testSimpleJUnitTestSuccess() {
+        SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
+        SimpleReportEntry testCase = createTestCase(testSet, "testMethod");
+
+        TestSetStats testSetStats = new TestSetStats(true, true);
+        testSetStats.testSucceeded(new WrappedReportEntry(testCase, ReportEntryType.SUCCESS, 120, null, null));
+        WrappedReportEntry wrappedReportEntry = new WrappedReportEntry(testSet, ReportEntryType.SUCCESS, 123, null, null);
+
+        reporter.testSetStarting(testSet);
+        reporter.testSetCompleted(wrappedReportEntry, testSetStats, EMPTY);
+
+        logger.assertInfoContains("Running net.sourceforge.pmd.test.Simple");
+        logger.assertInfoContains("Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 s - in net.sourceforge.pmd.test.Simple");
+    }
+
+    @Test
+    public void testSimpleJUnitTestFailure() {
+        SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
+        SimpleReportEntry testCase = createTestCase(testSet, "testFail");
+
+        TestSetStats testSetStats = new TestSetStats(true, true);
+        testSetStats.testFailure(new WrappedReportEntry(testCase, ReportEntryType.FAILURE, 1, null, null));
+        WrappedReportEntry wrappedReportEntry = new WrappedReportEntry(testSet, ReportEntryType.FAILURE, 1, null, null);
+
+        reporter.testSetStarting(testSet);
+        reporter.testSetCompleted(wrappedReportEntry, testSetStats, EMPTY);
+
+        logger.assertInfo(
+                "Running net.sourceforge.pmd.test.Simple" + NL
+                 + "    └─ ✘ testFail" + NL
+                 + "Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in net.sourceforge.pmd.test.Simple" + NL);
+    }
+
+    @Test
+    public void testNestedTestSets() {
+        SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
+        SimpleReportEntry testSetNested = createTestSet("net.sourceforge.pmd.test.Simple", "net.sourceforge.pmd.test.Simple Nested Group 1");
+        SimpleReportEntry testSetNested2 = createTestSet("net.sourceforge.pmd.test.Simple", "net.sourceforge.pmd.test.Simple Nested Group 1 Another Level");
+        SimpleReportEntry testCase = createTestCaseKotest(testSetNested2, "net.sourceforge.pmd.test.Simple Nested Group 1 Another Level The actual test case name");
+
+        TestSetStats testSetStats = new TestSetStats(true, true);
+        testSetStats.testFailure(new WrappedReportEntry(testCase, ReportEntryType.FAILURE, 1, null, null));
+        WrappedReportEntry wrappedTestSetNested2 = new WrappedReportEntry(testSetNested2, ReportEntryType.FAILURE, 1, null, null);
+        WrappedReportEntry wrappedTestSetNested = new WrappedReportEntry(testSetNested, ReportEntryType.FAILURE, 1, null, null);
+        WrappedReportEntry wrappedTestSet = new WrappedReportEntry(testSet, ReportEntryType.FAILURE, 1, null, null);
+
+        reporter.testSetStarting(testSet);
+        reporter.testSetStarting(testSetNested);
+        reporter.testSetStarting(testSetNested2);
+        reporter.testSetCompleted(wrappedTestSetNested2, testSetStats, EMPTY);
+        reporter.testSetCompleted(wrappedTestSetNested, EMPTY_STATS, EMPTY);
+        reporter.testSetCompleted(wrappedTestSet, EMPTY_STATS, EMPTY);
+
+        logger.assertInfo(
+                "Running net.sourceforge.pmd.test.Simple" + NL
+                 + "    └─ Nested Group 1" + NL
+                 + "        └─ Another Level" + NL
+                 + "            └─ ✘  The actual test case name" + NL
+                 + "Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.003 s <<< FAILURE! - in net.sourceforge.pmd.test.Simple" + NL
+        );
+    }
+
+    @Test
+    public void testNestedTestSetsUnnamed() {
+        SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
+        SimpleReportEntry testSetNested = createTestSet("net.sourceforge.pmd.test.Simple", "net.sourceforge.pmd.test.Simple Nested Group 1");
+        SimpleReportEntry testSetNested2 = createTestSet("net.sourceforge.pmd.test.Simple", "net.sourceforge.pmd.test.Simple Nested Group 1 Another Level");
+        SimpleReportEntry testCase = createTestCaseKotest(testSetNested2, "net.sourceforge.pmd.test.Simple Nested Group 1 Another Level");
+
+        TestSetStats testSetStats = new TestSetStats(true, true);
+        testSetStats.testFailure(new WrappedReportEntry(testCase, ReportEntryType.FAILURE, 1, null, null));
+        WrappedReportEntry wrappedTestSetNested2 = new WrappedReportEntry(testSetNested2, ReportEntryType.FAILURE, 1, null, null);
+        WrappedReportEntry wrappedTestSetNested = new WrappedReportEntry(testSetNested, ReportEntryType.FAILURE, 1, null, null);
+        WrappedReportEntry wrappedTestSet = new WrappedReportEntry(testSet, ReportEntryType.FAILURE, 1, null, null);
+
+        reporter.testSetStarting(testSet);
+        reporter.testSetStarting(testSetNested);
+        reporter.testSetStarting(testSetNested2);
+        reporter.testSetCompleted(wrappedTestSetNested2, testSetStats, EMPTY);
+        reporter.testSetCompleted(wrappedTestSetNested, EMPTY_STATS, EMPTY);
+        reporter.testSetCompleted(wrappedTestSet, EMPTY_STATS, EMPTY);
+
+        logger.assertInfo(
+                "Running net.sourceforge.pmd.test.Simple" + NL
+                        + "    └─ Nested Group 1" + NL
+                        + "        └─ Another Level" + NL
+                        + "            └─ ✘ [unnamed test case]" + NL
+                        + "Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.003 s <<< FAILURE! - in net.sourceforge.pmd.test.Simple" + NL
+        );
+    }
+
+    private SimpleReportEntry createTestSet(String className) {
+        return createTestSet(className, null);
+    }
+    private SimpleReportEntry createTestSet(String className, String sourceText) {
+        return new SimpleReportEntry(RunMode.NORMAL_RUN, testRunId++, className, sourceText, null, null);
+    }
+    private SimpleReportEntry createTestCase(SimpleReportEntry testSet, String methodName) {
+        return new SimpleReportEntry(RunMode.NORMAL_RUN, testRunId++, testSet.getSourceName(), null, methodName, null);
+    }
+    private SimpleReportEntry createTestCaseKotest(SimpleReportEntry testSet, String sourceText) {
+        return new SimpleReportEntry(RunMode.NORMAL_RUN, testRunId++, testSet.getSourceName(), sourceText, null, null);
+    }
+}

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.buildtools.surefire;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.maven.plugin.surefire.report.ReportEntryType;
@@ -54,15 +55,16 @@ public class AccumulatingConsoleReporterTest {
 
         TestSetStats testSetStats = new TestSetStats(true, true);
         testSetStats.testFailure(new WrappedReportEntry(testCase, ReportEntryType.FAILURE, 1, null, null));
-        WrappedReportEntry wrappedReportEntry = new WrappedReportEntry(testSet, ReportEntryType.FAILURE, 1, null, null);
+        WrappedReportEntry wrappedReportEntry = new WrappedReportEntry(testSet, null, 1, null, null);
 
         reporter.testSetStarting(testSet);
-        reporter.testSetCompleted(wrappedReportEntry, testSetStats, EMPTY);
+        reporter.testSetCompleted(wrappedReportEntry, testSetStats, Arrays.asList("Stacktrace..."));
 
         logger.assertInfo(
                 "Running net.sourceforge.pmd.test.Simple" + NL
                  + "    └─ ✘ testFail" + NL
                  + "Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in net.sourceforge.pmd.test.Simple" + NL);
+        logger.assertError("Stacktrace..." + NL);
     }
 
     @Test

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/MockedConsoleLogger.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/MockedConsoleLogger.java
@@ -1,0 +1,68 @@
+package net.sourceforge.pmd.buildtools.surefire;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+
+class MockedConsoleLogger implements ConsoleLogger {
+    private StringBuilder info = new StringBuilder();
+
+    @Override
+    public boolean isDebugEnabled() {
+        return false;
+    }
+
+    @Override
+    public void debug(String message) {
+
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return false;
+    }
+
+    @Override
+    public void info(String message) {
+        info.append(message).append(System.lineSeparator());
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return false;
+    }
+
+    @Override
+    public void warning(String message) {
+
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return false;
+    }
+
+    @Override
+    public void error(String message) {
+
+    }
+
+    @Override
+    public void error(String message, Throwable t) {
+
+    }
+
+    @Override
+    public void error(Throwable t) {
+
+    }
+
+    public void assertInfoContains(String s) {
+        assertThat(info.toString(), containsString(s));
+    }
+    public void assertInfo(String s) {
+        assertThat(info.toString(), equalTo(s));
+    }
+}

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/MockedConsoleLogger.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/MockedConsoleLogger.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 
 class MockedConsoleLogger implements ConsoleLogger {
     private StringBuilder info = new StringBuilder();
+    private StringBuilder error = new StringBuilder();
 
     @Override
     public boolean isDebugEnabled() {
@@ -46,7 +47,7 @@ class MockedConsoleLogger implements ConsoleLogger {
 
     @Override
     public void error(String message) {
-
+        error.append(message).append(System.lineSeparator());
     }
 
     @Override
@@ -62,7 +63,12 @@ class MockedConsoleLogger implements ConsoleLogger {
     public void assertInfoContains(String s) {
         assertThat(info.toString(), containsString(s));
     }
+
     public void assertInfo(String s) {
         assertThat(info.toString(), equalTo(s));
+    }
+
+    public void assertError(String s) {
+        assertThat(error.toString(), equalTo(s));
     }
 }


### PR DESCRIPTION
This will fix pmd/pmd#4236

This adds a console reporter for surefire, that can deal with JUnit and Kotest tests properly.