### PR TITLE
Improve surefire reporter

### DIFF
--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporter.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporter.java
@@ -125,6 +125,10 @@ class AccumulatingConsoleReporter extends StatelessTestsetInfoConsoleReportEvent
             }
         }
 
+        if (nesting.size() == 1) {
+            prefix = indentation + prefix;
+        }
+
         String testSetName = getTestSetName(report);
         // individual tests
         for (WrappedReportEntry entry : testSetStats.getReportEntries()) {

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporter.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporter.java
@@ -147,6 +147,10 @@ class AccumulatingConsoleReporter extends StatelessTestsetInfoConsoleReportEvent
         }
 
         if (nesting.size() == 1) {
+            if (accumulated.getCompletedCount() == 0) {
+                accumulatedTestResults.get(outerTestClass).add("No tests were executed! Test class: " + outerTestClass);
+            }
+
             WrappedReportEntry reportWithTotalElapsedMillis = new WrappedReportEntry(report,
                     report.getReportEntryType(), elapsedMillis, null, null);
             getConsoleLogger().info(indentation + accumulated.getColoredTestSetSummary(reportWithTotalElapsedMillis, false));
@@ -163,7 +167,7 @@ class AccumulatingConsoleReporter extends StatelessTestsetInfoConsoleReportEvent
     }
 
     private void printTestResults(TestSetStats accumulated, List<String> testResults) {
-        if (accumulated.getErrors() > 0 || accumulated.getFailures() > 0) {
+        if (accumulated.getErrors() > 0 || accumulated.getFailures() > 0 || accumulated.getCompletedCount() == 0) {
             for (String line : testResults) {
                 getConsoleLogger().error(line);
             }

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
@@ -182,6 +182,24 @@ public class AccumulatingConsoleReporterTest {
         );
     }
 
+    @Test
+    void failForEmptyTestSet() {
+        SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
+
+        WrappedReportEntry wrappedReportEntry = new WrappedReportEntry(testSet, ReportEntryType.SUCCESS, 123, null, null);
+
+        reporter.testSetStarting(testSet);
+        reporter.testSetCompleted(wrappedReportEntry, EMPTY_STATS, EMPTY);
+
+        logger.assertInfo(
+                "Running net.sourceforge.pmd.test.Simple" + NL +
+                        "Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 s -- in net.sourceforge.pmd.test.Simple" + NL
+        );
+        logger.assertError(
+                "No tests were executed! Test class: net.sourceforge.pmd.test.Simple" + NL
+        );
+    }
+
     private SimpleReportEntry createTestSet(String className) {
         return createTestSet(className, null);
     }

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
@@ -49,6 +49,25 @@ public class AccumulatingConsoleReporterTest {
     }
 
     @Test
+    void simpleJUnitTestSuccessWithShowSuccessful() {
+        reporter = new AccumulatingConsoleReporter(logger, true, true, true);
+        SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
+        SimpleReportEntry testCase = createTestCase(testSet, "testMethod");
+
+        TestSetStats testSetStats = new TestSetStats(true, true);
+        testSetStats.testSucceeded(new WrappedReportEntry(testCase, ReportEntryType.SUCCESS, 120, null, null));
+        WrappedReportEntry wrappedReportEntry = new WrappedReportEntry(testSet, ReportEntryType.SUCCESS, 123, null, null);
+
+        reporter.testSetStarting(testSet);
+        reporter.testSetCompleted(wrappedReportEntry, testSetStats, EMPTY);
+
+        logger.assertInfo(
+                "Running net.sourceforge.pmd.test.Simple" + NL
+                        + "    └─ ✔ testMethod" + NL
+                        + "Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 s -- in net.sourceforge.pmd.test.Simple" + NL);
+    }
+
+    @Test
     void testSimpleJUnitTestFailure() {
         SimpleReportEntry testSet = createTestSet("net.sourceforge.pmd.test.Simple");
         SimpleReportEntry testCase = createTestCase(testSet, "testFail");
@@ -155,7 +174,7 @@ public class AccumulatingConsoleReporterTest {
         logger.assertInfo(
                 "Running net.sourceforge.pmd.test.Suite" + NL +
                 "    Running net.sourceforge.pmd.test.Simple1" + NL +
-                "    └─ ✘ testFailMethod" + NL +
+                "        └─ ✘ testFailMethod" + NL +
                 "    Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.122 s <<< FAILURE! -- in net.sourceforge.pmd.test.Simple1" + NL +
                 "    Running net.sourceforge.pmd.test.Simple2" + NL +
                 "    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.124 s -- in net.sourceforge.pmd.test.Simple2" + NL +

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/AccumulatingConsoleReporterTest.java
@@ -125,6 +125,44 @@ public class AccumulatingConsoleReporterTest {
         );
     }
 
+    @Test
+    void junitSuiteReport() {
+        SimpleReportEntry testSuite = createTestSet("net.sourceforge.pmd.test.Suite");
+        SimpleReportEntry testSet1 = createTestSet("net.sourceforge.pmd.test.Simple1");
+        SimpleReportEntry testSet2 = createTestSet("net.sourceforge.pmd.test.Simple2");
+        SimpleReportEntry testCase1 = createTestCase(testSet1, "testMethod");
+        SimpleReportEntry testCase2 = createTestCase(testSet1, "testFailMethod");
+        SimpleReportEntry testCase3 = createTestCase(testSet2, "testMethod");
+
+        TestSetStats testSet1Stats = new TestSetStats(true, true);
+        testSet1Stats.testSucceeded(new WrappedReportEntry(testCase1, ReportEntryType.SUCCESS, 120, null, null));
+        testSet1Stats.testFailure(new WrappedReportEntry(testCase2, ReportEntryType.FAILURE, 121, null, null));
+        WrappedReportEntry testSet1Report = new WrappedReportEntry(testSet1, ReportEntryType.FAILURE, 122, null, null);
+
+        TestSetStats testSet2Stats = new TestSetStats(true, true);
+        testSet2Stats.testSucceeded(new WrappedReportEntry(testCase3, ReportEntryType.SUCCESS, 123, null, null));
+        WrappedReportEntry testSet2Report = new WrappedReportEntry(testSet2, ReportEntryType.SUCCESS, 124, null, null);
+
+        WrappedReportEntry testSuiteReport = new WrappedReportEntry(testSuite, ReportEntryType.SUCCESS, 125, null, null);
+
+        reporter.testSetStarting(testSuite);
+        reporter.testSetStarting(testSet1);
+        reporter.testSetCompleted(testSet1Report, testSet1Stats, EMPTY);
+        reporter.testSetStarting(testSet2);
+        reporter.testSetCompleted(testSet2Report, testSet2Stats, EMPTY);
+        reporter.testSetCompleted(testSuiteReport, EMPTY_STATS, EMPTY);
+
+        logger.assertInfo(
+                "Running net.sourceforge.pmd.test.Suite" + NL +
+                "    Running net.sourceforge.pmd.test.Simple1" + NL +
+                "    └─ ✘ testFailMethod" + NL +
+                "    Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.122 s <<< FAILURE! -- in net.sourceforge.pmd.test.Simple1" + NL +
+                "    Running net.sourceforge.pmd.test.Simple2" + NL +
+                "    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.124 s -- in net.sourceforge.pmd.test.Simple2" + NL +
+                "Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.371 s <<< FAILURE! -- in net.sourceforge.pmd.test.Suite" + NL
+        );
+    }
+
     private SimpleReportEntry createTestSet(String className) {
         return createTestSet(className, null);
     }


### PR DESCRIPTION
Refs https://github.com/pmd/pmd/issues/5009

The reporter now accumulates the suite tests, so that we don't end up with a line "Tests run: 0...".

It also logs an error, if a test set didn't contain any tests - which indicates a empty test class, which might be a missing `@Test` (Junit5) or `doTest` (kotest). Unfortunately, this is just a reporter, so we can't fail the build if this is encountered.
