### PR TITLE
Custom surefire-provider for junit platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.release>8</maven.compiler.release>
         <pmd.version>7.0.0</pmd.version> <!-- pmd version used for tests -->
         <surefire.version>3.2.5</surefire.version>
-        <junit.version>5.10.2</junit.version>
+        <junit.version>5.8.2</junit.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <maven.compiler.release>8</maven.compiler.release>
         <pmd.version>7.0.0</pmd.version> <!-- pmd version used for tests -->
         <surefire.version>3.2.5</surefire.version>
+        <junit.version>5.10.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -70,7 +71,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -84,6 +85,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>maven-surefire-common</artifactId>

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/JUnitPlatformProvider.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/JUnitPlatformProvider.java
@@ -2,7 +2,8 @@ package net.sourceforge.pmd.buildtools.surefire.junit;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
-import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.maven.surefire.api.provider.AbstractProvider;
 import org.apache.maven.surefire.api.provider.ProviderParameters;
@@ -14,6 +15,7 @@ import org.apache.maven.surefire.api.testset.TestListResolver;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.apache.maven.surefire.api.util.ScanResult;
 import org.apache.maven.surefire.api.util.TestsToRun;
+import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.launcher.Launcher;
@@ -74,13 +76,14 @@ public class JUnitPlatformProvider extends AbstractProvider {
     }
 
     private void runTests(LauncherSession session, TestsToRun testsToRun, TestExecutionListener testExecutionListener) {
+        List<DiscoverySelector> selectors = new ArrayList<>();
+        testsToRun.iterator().forEachRemaining(testClass -> selectors.add(selectClass(testClass)));
+
         Launcher launcher = session.getLauncher();
-        testsToRun.iterator().forEachRemaining(testClass -> {
-            TestPlan testPlan = launcher.discover(LauncherDiscoveryRequestBuilder.request()
-                    .selectors(selectClass(testClass))
-                    .build());
-            launcher.execute(testPlan, testExecutionListener);
-        });
+        TestPlan testPlan = launcher.discover(LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectors)
+                .build());
+        launcher.execute(testPlan, testExecutionListener);
     }
 
     /**

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/JUnitPlatformProvider.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/JUnitPlatformProvider.java
@@ -1,0 +1,104 @@
+package net.sourceforge.pmd.buildtools.surefire.junit;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.maven.surefire.api.provider.AbstractProvider;
+import org.apache.maven.surefire.api.provider.ProviderParameters;
+import org.apache.maven.surefire.api.report.ReporterException;
+import org.apache.maven.surefire.api.report.ReporterFactory;
+import org.apache.maven.surefire.api.report.TestOutputReportEntry;
+import org.apache.maven.surefire.api.report.TestReportListener;
+import org.apache.maven.surefire.api.suite.RunResult;
+import org.apache.maven.surefire.api.testset.TestListResolver;
+import org.apache.maven.surefire.api.testset.TestSetFailedException;
+import org.apache.maven.surefire.api.util.ScanResult;
+import org.apache.maven.surefire.api.util.TestsToRun;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.discovery.ClassNameFilter;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+/**
+ * A Surefire Provider for JUnit Platform. It reports only one test set per test class,
+ * uses the UniqueId of the test cases to identify single test cases (as opposed to use
+ * methods names, which are not available by Kotest).
+ *
+ * <p>It reports any test class, which doesn't contain test cases, as failed. This
+ * indicates a problem in the test setup.
+ */
+public class JUnitPlatformProvider extends AbstractProvider {
+    private final ProviderParameters parameters;
+
+    public JUnitPlatformProvider(ProviderParameters parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public Iterable<Class<?>> getSuites() {
+        try (LauncherSession session = LauncherFactory.openSession()) {
+            return findTests(session);
+        }
+    }
+
+    @Override
+    public RunResult invoke(Object forkTestSet) throws TestSetFailedException, ReporterException, InvocationTargetException {
+        ReporterFactory reporterFactory = parameters.getReporterFactory();
+
+        final RunResult result;
+        try (LauncherSession session = LauncherFactory.openSession()) {
+            final TestsToRun testsToRun;
+            if (forkTestSet instanceof TestsToRun) {
+                testsToRun = (TestsToRun) forkTestSet;
+            } else if (forkTestSet instanceof Class) {
+                testsToRun = TestsToRun.fromClass((Class<?>) forkTestSet);
+            } else if (forkTestSet == null) {
+                testsToRun = findTests(session);
+            } else {
+                throw new IllegalArgumentException("Invalid forkTestSet parameter: " + forkTestSet);
+            }
+
+            runTests(session, testsToRun, reporterFactory.createTestReportListener());
+
+        } finally {
+            result = reporterFactory.close();
+        }
+
+        return result;
+    }
+
+    private void runTests(LauncherSession session, TestsToRun testsToRun, TestReportListener<TestOutputReportEntry> testReportListener) {
+        Launcher launcher = session.getLauncher();
+        testsToRun.iterator().forEachRemaining(testClass -> {
+            TestPlan testPlan = launcher.discover(LauncherDiscoveryRequestBuilder.request()
+                    .selectors(selectClass(testClass))
+                    .build());
+            launcher.execute(testPlan, new TestExecutionListener(testReportListener));
+        });
+    }
+
+    /**
+     * Determines the tests to run - taking {@code -Dtest=...} param into account.
+     */
+    private TestsToRun findTests(LauncherSession session) {
+        ScanResult scanResult = parameters.getScanResult();
+        TestListResolver testListResolver = parameters.getTestRequest().getTestListResolver();
+        return scanResult.applyFilter(testClass -> {
+            TestPlan testPlan = session.getLauncher().discover(
+                    LauncherDiscoveryRequestBuilder.request()
+                            .selectors(selectClass(testClass))
+                            .filters((ClassNameFilter) className -> {
+                                String classFileName = TestListResolver.toClassFileName(className);
+                                boolean shouldRun = testListResolver.shouldRun(classFileName, null);
+                                return FilterResult.includedIf(shouldRun);
+                            })
+                            .build()
+            );
+            return testPlan.containsTests();
+        }, parameters.getTestClassLoader());
+    }
+}

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/RootContainer.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/RootContainer.java
@@ -1,5 +1,6 @@
 package net.sourceforge.pmd.buildtools.surefire.junit;
 
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestIdentifier;
 
 class RootContainer {
@@ -19,6 +20,7 @@ class RootContainer {
     }
 
     public boolean hasNoTests() {
-        return !hasTests;
+        return !testIdentifier.getUniqueIdObject().hasPrefix(UniqueId.forEngine("junit-platform-suite"))
+            && !hasTests;
     }
 }

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/RootContainer.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/RootContainer.java
@@ -1,0 +1,24 @@
+package net.sourceforge.pmd.buildtools.surefire.junit;
+
+import org.junit.platform.launcher.TestIdentifier;
+
+class RootContainer {
+    private final TestIdentifier testIdentifier;
+    private boolean hasTests = false;
+
+    public RootContainer(TestIdentifier testIdentifier) {
+        this.testIdentifier = testIdentifier;
+    }
+
+    public boolean isIdentifier(TestIdentifier testIdentifier) {
+        return this.testIdentifier.equals(testIdentifier);
+    }
+
+    public void markHasAtLeastOneTest() {
+        hasTests = true;
+    }
+
+    public boolean hasNoTests() {
+        return !hasTests;
+    }
+}

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListener.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListener.java
@@ -1,0 +1,151 @@
+package net.sourceforge.pmd.buildtools.surefire.junit;
+
+import java.lang.management.ManagementFactory;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.maven.surefire.api.report.LegacyPojoStackTraceWriter;
+import org.apache.maven.surefire.api.report.RunMode;
+import org.apache.maven.surefire.api.report.SimpleReportEntry;
+import org.apache.maven.surefire.api.report.TestOutputReportEntry;
+import org.apache.maven.surefire.api.report.TestReportListener;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+
+class TestExecutionListener implements org.junit.platform.launcher.TestExecutionListener {
+    private final AtomicLong testIdGenerator = new AtomicLong();
+    private final Map<String, Long> testIdMapping = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, RootContainer> rootContainers = new ConcurrentHashMap<>();
+
+    private final TestReportListener<TestOutputReportEntry> testReportListener;
+
+    public TestExecutionListener(TestReportListener<TestOutputReportEntry> testReportListener) {
+        this.testReportListener = testReportListener;
+    }
+
+    @Override
+    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+        determineRootContainer(testIdentifier).ifPresent(RootContainer::markHasAtLeastOneTest);
+        testReportListener.testSkipped(toReportEntry(testIdentifier));
+    }
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        if (testIdentifier.isContainer()) {
+            Optional<String> rootClass = determineRootClass(testIdentifier);
+            if (rootClass.isPresent()) {
+                RootContainer previous = rootContainers.putIfAbsent(rootClass.get(), new RootContainer(testIdentifier));
+                if (previous == null) {
+                    testReportListener.testSetStarting(toTestSetReportEntry(testIdentifier));
+                }
+            }
+        } else {
+            SimpleReportEntry reportEntry = toReportEntry(testIdentifier);
+            testReportListener.testStarting(reportEntry);
+        }
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        Map<String, String> systemProps = ManagementFactory.getRuntimeMXBean().getSystemProperties();
+
+        if (testIdentifier.isContainer()) {
+            Optional<String> rootClass = determineRootClass(testIdentifier);
+            Optional<RootContainer> rootContainer = determineRootContainer(testIdentifier);
+            if (rootClass.isPresent() && rootContainer.isPresent()) {
+                if (rootContainer.get().isIdentifier(testIdentifier)) {
+                    RootContainer removed = rootContainers.remove(rootClass.get());
+                    if (removed != null) {
+                        if (removed.hasNoTests()) {
+                            String message = "No Tests have been executed in Test Set";
+                            testReportListener.testError(toReportEntry(testIdentifier, message, new IllegalStateException(message), Collections.emptyMap()));
+                        }
+                        testReportListener.testSetCompleted(toTestSetReportEntry(testIdentifier));
+                    }
+                }
+            }
+        } else {
+            String message = testExecutionResult.getThrowable().map(Throwable::getMessage).orElse(null);
+            boolean isAssertionError = testExecutionResult.getThrowable().map(AssertionError.class::isInstance).orElse(false);
+            SimpleReportEntry reportEntry = toReportEntry(testIdentifier, message,
+                    testExecutionResult.getThrowable().orElse(null), systemProps);
+
+            determineRootContainer(testIdentifier).ifPresent(RootContainer::markHasAtLeastOneTest);
+            switch (testExecutionResult.getStatus()) {
+                case SUCCESSFUL:
+                    testReportListener.testSucceeded(reportEntry);
+                    break;
+                case FAILED:
+                    if (isAssertionError) {
+                        testReportListener.testFailed(reportEntry);
+                    } else {
+                        testReportListener.testError(reportEntry);
+                    }
+                    break;
+                case ABORTED:
+                    testReportListener.testAssumptionFailure(reportEntry);
+                    break;
+            }
+        }
+    }
+
+    private long determineRunId(TestIdentifier testIdentifier) {
+        return testIdMapping.computeIfAbsent(testIdentifier.getUniqueId(), (id) -> testIdGenerator.incrementAndGet());
+    }
+
+    private Optional<String> determineRootClass(TestIdentifier testIdentifier) {
+        Optional<String> classNameFromClassSource = testIdentifier.getSource()
+                .filter(ClassSource.class::isInstance)
+                .map(ClassSource.class::cast)
+                .map(ClassSource::getClassName);
+        Optional<String> classNameFromMethodSource = testIdentifier.getSource()
+                .filter(MethodSource.class::isInstance)
+                .map(MethodSource.class::cast)
+                .map(MethodSource::getClassName);
+
+        if (classNameFromMethodSource.isPresent()) {
+            return classNameFromMethodSource;
+        }
+        return classNameFromClassSource;
+    }
+
+    private Optional<RootContainer> determineRootContainer(TestIdentifier testIdentifier) {
+        return determineRootClass(testIdentifier).map(rootContainers::get);
+    }
+
+    private SimpleReportEntry toReportEntry(TestIdentifier testIdentifier) {
+        return toReportEntry(testIdentifier, null, null, Collections.emptyMap());
+    }
+
+    private SimpleReportEntry toReportEntry(TestIdentifier testIdentifier, String message, Throwable throwable,
+                                            Map<String, String> systemProps) {
+        return new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                determineRunId(testIdentifier),
+                testIdentifier.getDisplayName(),
+                testIdentifier.getDisplayName(),
+                testIdentifier.getUniqueId(),
+                testIdentifier.getUniqueId(),
+                new LegacyPojoStackTraceWriter(testIdentifier.getDisplayName(), null, throwable),
+                0,
+                message,
+                systemProps
+        );
+    }
+
+    private SimpleReportEntry toTestSetReportEntry(TestIdentifier testIdentifier) {
+        return new SimpleReportEntry(
+                RunMode.NORMAL_RUN,
+                determineRunId(testIdentifier),
+                testIdentifier.getDisplayName(),
+                testIdentifier.getDisplayName(),
+                null, null
+        );
+    }
+}

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListener.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListener.java
@@ -147,10 +147,11 @@ class TestExecutionListener implements org.junit.platform.launcher.TestExecution
     }
 
     private SimpleReportEntry toTestSetReportEntry(TestIdentifier testIdentifier) {
+        String testClass = determineRootClass(testIdentifier).orElse(testIdentifier.getDisplayName());
         return new SimpleReportEntry(
                 RunMode.NORMAL_RUN,
                 determineRunId(testIdentifier),
-                testIdentifier.getDisplayName(),
+                testClass,
                 testIdentifier.getDisplayName(),
                 null, null
         );

--- a/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListener.java
+++ b/src/main/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListener.java
@@ -16,6 +16,7 @@ import org.apache.maven.surefire.api.report.TestOutputReceiver;
 import org.apache.maven.surefire.api.report.TestOutputReportEntry;
 import org.apache.maven.surefire.api.report.TestReportListener;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestIdentifier;
@@ -115,11 +116,19 @@ class TestExecutionListener implements org.junit.platform.launcher.TestExecution
                 .filter(MethodSource.class::isInstance)
                 .map(MethodSource.class::cast)
                 .map(MethodSource::getClassName);
+        Optional<String> classNameFromUniqueId = testIdentifier.getUniqueIdObject()
+                .getSegments().stream()
+                .filter(s -> "class".equals(s.getType()))
+                .map(UniqueId.Segment::getValue)
+                .findFirst();
 
         if (classNameFromMethodSource.isPresent()) {
             return classNameFromMethodSource;
         }
-        return classNameFromClassSource;
+        if (classNameFromClassSource.isPresent()) {
+            return classNameFromClassSource;
+        }
+        return classNameFromUniqueId;
     }
 
     private Optional<RootContainer> determineRootContainer(TestIdentifier testIdentifier) {

--- a/src/main/resources/META-INF/services/org.apache.maven.surefire.api.provider.SurefireProvider
+++ b/src/main/resources/META-INF/services/org.apache.maven.surefire.api.provider.SurefireProvider
@@ -1,0 +1,1 @@
+net.sourceforge.pmd.buildtools.surefire.junit.JUnitPlatformProvider

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListenerTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListenerTest.java
@@ -1,0 +1,365 @@
+package net.sourceforge.pmd.buildtools.surefire.junit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.TestOutputReportEntry;
+import org.apache.maven.surefire.api.report.TestReportListener;
+import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+
+class TestExecutionListenerTest {
+
+    @Test
+    void singleTest() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
+        TestDescriptor testCase = new MyTestDescriptor("MyTestClass", "myTest");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionStarted(TestIdentifier.from(testCase));
+        listener.executionFinished(TestIdentifier.from(testCase), TestExecutionResult.successful());
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(1, 1, 0);
+    }
+
+    @Test
+    void skippedTest() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
+        TestDescriptor testCase1 = new MyTestDescriptor("MyTestClass", "myTest");
+        TestDescriptor testCase2 = new MyTestDescriptor("MyTestClass", "myTestSkipped");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionStarted(TestIdentifier.from(testCase1));
+        listener.executionFinished(TestIdentifier.from(testCase1), TestExecutionResult.successful());
+        listener.executionSkipped(TestIdentifier.from(testCase2), "reason");
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(1, 1, 0, 0, 1);
+    }
+
+    @Test
+    void errorForEmptyTestSet() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(0, 0, 0, 1, 0);
+    }
+
+    @Test
+    void failedTest() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
+        TestDescriptor testCase1 = new MyTestDescriptor("MyTestClass", "myTest");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionStarted(TestIdentifier.from(testCase1));
+        listener.executionFinished(TestIdentifier.from(testCase1), TestExecutionResult.failed(new AssertionError("test")));
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(1, 0, 1);
+    }
+
+    @Test
+    void erroredTest() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
+        TestDescriptor testCase1 = new MyTestDescriptor("MyTestClass", "myTest");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionStarted(TestIdentifier.from(testCase1));
+        listener.executionFinished(TestIdentifier.from(testCase1), TestExecutionResult.failed(new RuntimeException("test")));
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(1, 0, 0, 1, 0);
+    }
+
+    @Test
+    void nestedTestSets() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet1 = new MyTestDescriptor("MyTestClass");
+        TestDescriptor testSet2 = new MyTestDescriptor("MyTestClass", new String[] {"nesting"}, false);
+        TestDescriptor testCase1 = new MyTestDescriptor("MyTestClass", new String[] {"nesting", "myTest"}, true);
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet1));
+        listener.executionStarted(TestIdentifier.from(testSet2));
+        listener.executionStarted(TestIdentifier.from(testCase1));
+        listener.executionFinished(TestIdentifier.from(testCase1), TestExecutionResult.successful());
+        listener.executionFinished(TestIdentifier.from(testSet2), TestExecutionResult.successful());
+        listener.executionFinished(TestIdentifier.from(testSet1), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(1, 1, 0);
+    }
+
+    @Test
+    void abortedTest() {
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
+        TestDescriptor testCase = new MyTestDescriptor("MyTestClass", "myTest");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionStarted(TestIdentifier.from(testCase));
+        listener.executionFinished(TestIdentifier.from(testCase), TestExecutionResult.aborted(null));
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(1, 1);
+        testReportListener.assertTests(1, 0, 0, 0, 0, 1);
+    }
+
+    private static class TestOutputReportEntryTestReportListener implements TestReportListener<TestOutputReportEntry> {
+        List<TestSetReportEntry> startingTestSets = new ArrayList<>();
+        List<TestSetReportEntry> completedTestSets = new ArrayList<>();
+        List<ReportEntry> startingTests = new ArrayList<>();
+        List<ReportEntry> successfulTests = new ArrayList<>();
+        List<ReportEntry> assumptionFailures = new ArrayList<>();
+        List<ReportEntry> failedTests = new ArrayList<>();
+        List<ReportEntry> skippedTests = new ArrayList<>();
+        List<ReportEntry> erroredTests = new ArrayList<>();
+
+        @Override
+        public boolean isDebugEnabled() {
+            return false;
+        }
+
+        @Override
+        public void debug(String s) {
+
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return false;
+        }
+
+        @Override
+        public void info(String s) {
+
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return false;
+        }
+
+        @Override
+        public void warning(String s) {
+
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return false;
+        }
+
+        @Override
+        public void error(String s) {
+
+        }
+
+        @Override
+        public void error(String s, Throwable throwable) {
+
+        }
+
+        @Override
+        public void error(Throwable throwable) {
+
+        }
+
+        @Override
+        public void testSetStarting(TestSetReportEntry report) {
+            startingTestSets.add(report);
+        }
+
+        @Override
+        public void testSetCompleted(TestSetReportEntry report) {
+            completedTestSets.add(report);
+        }
+
+        @Override
+        public void testStarting(ReportEntry report) {
+            startingTests.add(report);
+        }
+
+        @Override
+        public void testSucceeded(ReportEntry report) {
+            successfulTests.add(report);
+        }
+
+        @Override
+        public void testAssumptionFailure(ReportEntry report) {
+            assumptionFailures.add(report);
+        }
+
+        @Override
+        public void testError(ReportEntry report) {
+            erroredTests.add(report);
+        }
+
+        @Override
+        public void testFailed(ReportEntry report) {
+            failedTests.add(report);
+        }
+
+        @Override
+        public void testSkipped(ReportEntry report) {
+            skippedTests.add(report);
+        }
+
+        @Override
+        public void testExecutionSkippedByUser() {
+
+        }
+
+        @Override
+        public void writeTestOutput(TestOutputReportEntry reportEntry) {
+
+        }
+
+        public void assertTestSets(int starting, int completed) {
+            assertEquals(starting, startingTestSets.size(), "starting test sets");
+            assertEquals(completed, completedTestSets.size(), "completed test sets");
+        }
+
+        public void assertTests(int starting, int successful, int failed) {
+            assertTests(starting, successful, failed, 0, 0);
+        }
+
+        public void assertTests(int starting, int successful, int failed, int errored, int skipped) {
+            assertTests(starting, successful, failed, errored, skipped, 0);
+        }
+
+        public void assertTests(int starting, int successful, int failed, int errored, int skipped, int aborted) {
+            assertEquals(starting, startingTests.size(), "starting tests");
+            assertEquals(successful, successfulTests.size(), "successful tests");
+            assertEquals(failed, failedTests.size(), "failed tests");
+            assertEquals(errored, erroredTests.size(), "errored tests");
+            assertEquals(skipped, skippedTests.size(), "skipped tests");
+            assertEquals(aborted, assumptionFailures.size(), "assumptions failed");
+        }
+    }
+
+    private static class MyTestDescriptor implements TestDescriptor {
+        private final String testClass;
+        private final Type type;
+        private final UniqueId uniqueId;
+        private final TestSource source;
+
+        public MyTestDescriptor(String testClass) {
+            this.testClass = testClass;
+            this.type = Type.CONTAINER;
+            this.uniqueId = UniqueId.forEngine("jupiter").append("class", testClass);
+            this.source = ClassSource.from(testClass);
+        }
+
+        public MyTestDescriptor(String testClass, String testMethod) {
+            this.testClass = testClass;
+            this.type = Type.TEST;
+            this.uniqueId = UniqueId.forEngine("jupiter").append("class", testClass).append("method", testMethod);
+            this.source = MethodSource.from(testClass, testMethod);
+        }
+
+        public MyTestDescriptor(String testClass, String[] testMethods, boolean isTest) {
+            this.testClass = testClass;
+            this.type = isTest ? Type.TEST : Type.CONTAINER;
+            UniqueId uniqueId = UniqueId.forEngine("jupiter").append("class", testClass);
+            for (String testMethod : testMethods) {
+                uniqueId = uniqueId.append("method", testMethod);
+            }
+            this.uniqueId = uniqueId;
+            this.source = ClassSource.from(testClass);
+        }
+
+        @Override
+        public UniqueId getUniqueId() {
+            return uniqueId;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return testClass;
+        }
+
+        @Override
+        public Set<TestTag> getTags() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Optional<TestSource> getSource() {
+            return Optional.of(source);
+        }
+
+        @Override
+        public Optional<TestDescriptor> getParent() {
+            return Optional.empty();
+        }
+
+        @Override
+        public void setParent(TestDescriptor parent) {
+
+        }
+
+        @Override
+        public Set<? extends TestDescriptor> getChildren() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void addChild(TestDescriptor descriptor) {
+
+        }
+
+        @Override
+        public void removeChild(TestDescriptor descriptor) {
+
+        }
+
+        @Override
+        public void removeFromHierarchy() {
+
+        }
+
+        @Override
+        public Type getType() {
+            return type;
+        }
+
+        @Override
+        public Optional<? extends TestDescriptor> findByUniqueId(UniqueId uniqueId) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListenerTest.java
+++ b/src/test/java/net/sourceforge/pmd/buildtools/surefire/junit/TestExecutionListenerTest.java
@@ -72,6 +72,26 @@ class TestExecutionListenerTest {
     }
 
     @Test
+    void ignoreEmptySuiteTests() {
+        // [engine:junit-platform-suite]/[suite:net.sourceforge.pmd.renderers.RenderersTests]
+        TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
+        TestDescriptor testSuite = new MyTestDescriptor(UniqueId.forEngine("junit-platform-suite").append("suite", "MyTestClass"), "MyTestClass");
+        TestDescriptor testSet = new MyTestDescriptor("NestedTestClass");
+        TestDescriptor testCase = new MyTestDescriptor("NestedTestClass", "testMethod");
+
+        TestExecutionListener listener = new TestExecutionListener(testReportListener);
+        listener.executionStarted(TestIdentifier.from(testSuite));
+        listener.executionStarted(TestIdentifier.from(testSet));
+        listener.executionStarted(TestIdentifier.from(testCase));
+        listener.executionFinished(TestIdentifier.from(testCase), TestExecutionResult.successful());
+        listener.executionFinished(TestIdentifier.from(testSet), TestExecutionResult.successful());
+        listener.executionFinished(TestIdentifier.from(testSuite), TestExecutionResult.successful());
+
+        testReportListener.assertTestSets(2, 2);
+        testReportListener.assertTests(1, 1, 0, 0, 0);
+    }
+
+    @Test
     void failedTest() {
         TestOutputReportEntryTestReportListener testReportListener = new TestOutputReportEntryTestReportListener();
         TestDescriptor testSet = new MyTestDescriptor("MyTestClass");
@@ -281,6 +301,13 @@ class TestExecutionListenerTest {
             this.testClass = testClass;
             this.type = Type.CONTAINER;
             this.uniqueId = UniqueId.forEngine("jupiter").append("class", testClass);
+            this.source = ClassSource.from(testClass);
+        }
+
+        public MyTestDescriptor(UniqueId uniqueId, String testClass) {
+            this.testClass = testClass;
+            this.type = Type.CONTAINER;
+            this.uniqueId = uniqueId;
             this.source = ClassSource.from(testClass);
         }
 


### PR DESCRIPTION
This provider reports only one test set by test class, accumulating all tests that belong together. Furthermore, the unique id of the tests are used as method names to be sure that no two test cases have the same name, so that surefire's run statistics work correctly.

It fails any test set (aka. test class) if there were no test cases reported.

This is the workaround solution for last comment in https://github.com/pmd/pmd/pull/5022#issuecomment-2123250887

With that, the skipped tests are reported correctly now. And we will even notice, if we create kotests tests without tests (only consisting of containers).


Note: Merging this and using build-tools 25-SNAPSHOT in pmd will make pmd build to fail. I'll test, if pmd/pmd#5022 is enough to fix the tests or whether we have more problems.