### PR TITLE
checkstyle: Update RedundantModifier config to use the new 'jdkVersion' property

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -131,6 +131,7 @@
     </module>
     <module name="RedundantModifier">
       <property name="severity" value="error"/>
+      <property name="jdkVersion" value="8"/>
     </module>
     <module name="EmptyBlock">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
From failure at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/27241/workflows/ae4881cd-8f64-4245-a7c0-619e023f8e5e/jobs/662368 in https://github.com/checkstyle/checkstyle/pull/15376

`RedundantModifierCheck` becomes very dependent on Java version examples would be `strictfp` modifier and the `final` modifier on underscore variables. Checkstyle has introduced a property named `jdkVersion` in this check to give us the flexibility to handle various behaviors across different Java versions.

This PR uses the new property in the config file and sets its value to the current Java version of PMD.

When the next Checkstyle version is released, we can merge this PR after upgrading checkstyle


