### PR TITLE
Checkstyle: Replaced property scope with new accessModifiers for JavadocVariable check

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -38,7 +38,7 @@
     </module>
     <module name="JavadocVariable">
       <property name="severity" value="warning"/>
-      <property name="scope" value="protected"/>
+      <property name="accessModifiers" value="protected"/>
     </module>
     <module name="NonEmptyAtclauseDescription">
       <property name="severity" value="warning"/>


### PR DESCRIPTION
As per upcoming changes in https://github.com/checkstyle/checkstyle/pull/16049  for [JavadocVariable](https://checkstyle.org/checks/javadoc/javadocvariable.html#JavadocVariable) check, this PR replaces`scope` with new `accessModifiers` property. 

No further changes required in [pmd](https://github.com/pmd/pmd).

>[!NOTE]  
>This PR should be merged after the release of checkstyle 10.22.0