### PR TITLE
Refactor GitHub Actions Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,60 +1,61 @@
-name: build
+name: Build
 
 on:
+  pull_request:
+  merge_group:
   push:
     branches:
-      - main
+      - '**'
+      # don't run on dependabot branches. Dependabot will create pull requests, which will then be run instead
+      - '!dependabot/**'
     tags:
       - '**'
-  pull_request:
+  workflow_dispatch:
   schedule:
     # build it monthly: At 04:15 on day-of-month 1.
     - cron: '15 4 1 * *'
     # for testing the event "schedule": run every 15 minutes starting from minute 5 through 59 (0, 15, 30, 45)
     #- cron: '0/15 * * * *'
-  workflow_dispatch:
+
+# if another commit is added to the same branch or PR (same github.ref),
+# then cancel already running jobs and start a new build.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: false
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+  compile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.m2/repository
-          ~/.cache
-        key: ${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-
-    - name: Set up Ruby 3.3
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.3
-    - name: Setup Environment
-      shell: bash
-      run: |
-        echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        echo "MAVEN_OPTS=-Daether.connector.http.connectionMaxTtl=180 -DautoReleaseAfterClose=true" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/main/scripts" >> $GITHUB_ENV
-    - name: Check Environment
-      shell: bash
-      run: |
-        f=check-environment.sh; \
-        mkdir -p .ci && \
-        ( [ -e .ci/$f ] || curl -sSL "${PMD_CI_SCRIPTS_URL}/$f" > ".ci/$f" ) && \
-        chmod 755 .ci/$f && \
-        .ci/$f
-    - name: Build
-      run: .ci/build.sh
-      shell: bash
-      env:
-        PMD_CI_SECRET_PASSPHRASE: ${{ secrets.PMD_CI_SECRET_PASSPHRASE }}
-        PMD_CI_GPG_PRIVATE_KEY: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: .m2/repository
+          enableCrossOsArchive: true
+      - name: Build with Maven
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+            -Dmaven.repo.local=.m2/repository \
+            verify
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compile-artifact
+          if-no-files-found: error
+          path: |
+            target/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,16 +42,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: actions/cache@v4
-        with:
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
-          path: .m2/repository
-          enableCrossOsArchive: true
+          cache: 'maven'
       - name: Build with Maven
         run: |
           ./mvnw --show-version --errors --batch-mode \
-            -Dmaven.repo.local=.m2/repository \
             verify
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
       - name: Determine Version
         id: version
         run: |
@@ -63,17 +68,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: 'maven'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
-      - uses: actions/cache@v4
-        with:
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
-          path: .m2/repository
-          enableCrossOsArchive: true
       - name: Build and Publish
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -81,6 +81,5 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
         run: |
           ./mvnw --show-version --errors --batch-mode \
-            -Dmaven.repo.local=.m2/repository \
-            deploy \
-            -Psign
+            -Psign \
+            deploy

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,86 @@
+name: Publish Release
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+    branches:
+      - 'releases/**'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
+
+jobs:
+  check-version:
+    # only run in the official pmd/build-tools repo, where we have access to the secrets and not on forks
+    # and only run for _successful_ push workflow runs on tags "releases/**".
+    if: ${{ github.repository == 'pmd/build-tools'
+      && github.event.workflow_run.event == 'push'
+      && startsWith('releases/', github.event.workflow_run.head_branch)
+      && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - name: Determine Version
+        id: version
+        run: |
+          VERSION=$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Determined VERSION=$VERSION"
+          if [[ "$VERSION" = *-SNAPSHOT ]]; then
+            echo "::error ::VERSION=$VERSION is a snapshot version, aborting."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+  deploy-to-maven-central:
+    needs: check-version
+    # use environment maven-central, where secrets are configured for OSSRH_*
+    environment:
+      name: maven-central
+      url: https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-build-tools-config/
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: .m2/repository
+          enableCrossOsArchive: true
+      - name: Build and Publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+            -Dmaven.repo.local=.m2/repository \
+            deploy \
+            -Psign

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,7 +40,14 @@ jobs:
           cache: 'maven'
       - name: Determine Version
         id: version
+        env:
+          REF: ${{ github.event.workflow_run.head_branch }}
         run: |
+          if ! git show-ref --exists "refs/tags/$REF"; then
+            echo "::error ::Tag $REF does not exist, aborting."
+            exit 1
+          fi
+          
           VERSION=$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "Determined VERSION=$VERSION"
           if [[ "$VERSION" = *-SNAPSHOT ]]; then

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
       - name: Determine Version
         id: version
         run: |
@@ -63,17 +68,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: 'maven'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
-      - uses: actions/cache@v4
-        with:
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
-          path: .m2/repository
-          enableCrossOsArchive: true
       - name: Build and Publish
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -81,6 +81,5 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
         run: |
           ./mvnw --show-version --errors --batch-mode \
-            -Dmaven.repo.local=.m2/repository \
-            deploy \
-            -Psign
+            -Psign \
+            deploy

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,86 @@
+name: Publish Snapshot
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
+
+jobs:
+  check-version:
+    # only run in the official pmd/build-tools repo, where we have access to the secrets and not on forks
+    # and only run for _successful_ push workflow runs on branch "main".
+    if: ${{ github.repository == 'pmd/build-tools'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_branch == 'main'
+      && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Determine Version
+        id: version
+        run: |
+          VERSION=$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Determined VERSION=$VERSION"
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "::error ::VERSION=$VERSION is not a snapshot version, aborting."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+
+  deploy-to-maven-central:
+    needs: check-version
+    # use environment maven-central, where secrets are configured for OSSRH_*
+    environment:
+      name: maven-central
+      url: https://oss.sonatype.org/content/repositories/snapshots/net/sourceforge/pmd/pmd-build-tools-config/
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: .m2/repository
+          enableCrossOsArchive: true
+      - name: Build and Publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+            -Dmaven.repo.local=.m2/repository \
+            deploy \
+            -Psign

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
                         <pushChanges>true</pushChanges>
                         <localCheckout>true</localCheckout>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <tagNameFormat>@{project.version}</tagNameFormat>
+                        <tagNameFormat>releases/@{project.version}</tagNameFormat>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>

--- a/release-howto.md
+++ b/release-howto.md
@@ -1,27 +1,27 @@
-Release Howto for pmd-build
-============================
+# Release Howto for pmd-build
 
-Step by step
--------------
+## Step by step
+
 1. Checkout main branch:
 
-``` shell
-git clone https://github.com/pmd/build-tools.git
-cd build-tools
-```
+    ``` shell
+    git clone https://github.com/pmd/build-tools.git
+    cd build-tools
+    ```
 
-2. Prepare the release (creates a new release tag).
+2. Prepare the release (creates a new release tag named "releases/x").
    This will be done for you: http://maven.apache.org/plugins/maven-release-plugin/examples/prepare-release.html
    Maven will ask you about the release version, the tag name and the new version. You can simply hit enter,
    to use the default values.
 
-``` shell
-./mvnw release:clean
-./mvnw release:prepare
-```
+    ``` shell
+    ./mvnw release:clean
+    ./mvnw release:prepare
+    ```
 
 3.  Wait, until release is ready. The maven plugin will directly push the tag. The tag will be
-    built by [Github Actions](https://github.com/pmd/build-tools/actions?query=workflow%3Abuild).
+    built by GitHub Actions workflow [Build](https://github.com/pmd/build-tools/actions/workflows/build.yml)
+    followed by workflow [Publish Release](https://github.com/pmd/build-tools/actions/workflows/publish-release.yml).  
     After it is done, the new release
     should be available under <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-build-tools-config/>.
 


### PR DESCRIPTION
The goal is to have a similar structure for all PMD projects. This build-tools is the simplest one.

Improvements:

- We don't rely anymore on shell scripts and encrypted secrets that are committed. Instead, all secrets are configured on GitHub and are injected via environment variables.
- The main build.yml build can run also on forks, as it doesn't need any secrets.
- The two new workflows "publish-snapshot" and "publish-release" run after the "build" workflow and have access to the secrets.
- The build-tools will now be built only on linux, as there isn't be any os dependant functionality, that needs to be tested.

Refs pmd/pmd#4328