### PR TITLE
Update pmd-eclipse-imports.importorder

### DIFF
--- a/eclipse/pmd-eclipse-imports.importorder
+++ b/eclipse/pmd-eclipse-imports.importorder
@@ -1,8 +1,7 @@
 #Organize Import Order
 #Sun Nov 20 10:59:37 CET 2016
-5=
-4=net.sourceforge.pmd
-3=org
-2=javax
+4=
+3=net.sourceforge.pmd
+2=org
 1=java
 0=\#


### PR DESCRIPTION
having config applied turns out to be violating check config.

with this its in one block like commited.

fix gap:

- https://github.com/pmd/pmd/pull/5776

<img width="1816" alt="image" src="https://github.com/user-attachments/assets/95dd5404-2bcb-482c-b4d7-fb5d9e7b4c36" />
