### PR TITLE
Allow increments for AssignmentInOperand rule

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-dogfood-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-dogfood-config.xml
@@ -264,6 +264,7 @@
         <priority>1</priority>
         <properties>
             <property name="allowWhile" value="true"/>
+            <property name="allowIncrementDecrement" value="true"/>
         </properties>
     </rule>
     <rule ref="category/java/errorprone.xml/AssignmentToNonFinalStatic">


### PR DESCRIPTION
As discussed in https://github.com/pmd/pmd/pull/5972, allow i++ and similar in AssignmentInOperand.

Is this applied automatically once merged, or are more steps necessary?