### PR TITLE
Disable checkstyle MissingSwitchDefault rule

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -177,10 +177,6 @@
       <property name="severity" value="warning"/>
       <property name="constantWaiverParentToken" value="TYPECAST,METHOD_CALL,EXPR,ARRAY_INIT,UNARY_MINUS,UNARY_PLUS,ELIST,STAR,ASSIGN,PLUS,MINUS,DIV,LITERAL_NEW"/>
     </module>
-    <module name="MissingSwitchDefault">
-      <!-- The PMD rule NonExhaustiveSwitchStatement is better as it checks for exhaustivity -->
-      <property name="severity" value="warning"/>
-    </module>
     <module name="ModifiedControlVariable">
       <property name="severity" value="error"/>
     </module>


### PR DESCRIPTION
This check caused a checkstyle failure on https://github.com/pmd/pmd/pull/6037 even though the switch is exhaustive