### PR TITLE
Remove obsolete JavadocStyle from checkstyle config

### DIFF
--- a/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
+++ b/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml
@@ -27,11 +27,6 @@
       <property name="severity" value="warning"/>
       <property name="accessModifiers" value="public,protected"/>
     </module>
-    <module name="JavadocStyle">
-      <property name="severity" value="warning"/>
-      <property name="scope" value="protected"/>
-      <property name="checkEmptyJavadoc" value="true"/>
-    </module>
     <module name="JavadocType">
       <property name="severity" value="warning"/>
       <property name="scope" value="protected"/>


### PR DESCRIPTION
Removes `JavadocStyle` from the PMD Checkstyle configuration because the check is being removed from Checkstyle in PR https://github.com/checkstyle/checkstyle/pull/20582.

`SummaryJavadoc` is already configured, so no replacement is needed.